### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/ivy-clojuredocs.el
+++ b/ivy-clojuredocs.el
@@ -33,6 +33,7 @@
 (require 'browse-url)
 (require 'edn)
 (require 'cl-lib)
+(require 'subr-x)
 
 (defgroup ivy-clojuredocs nil
   "Ivy applications"


### PR DESCRIPTION
```
ivy-clojuredocs.el:146:1:Warning: the following functions are not known to be defined: string-empty-p,
    string-join
```